### PR TITLE
Fix for images with uppercase file extension

### DIFF
--- a/rimg.js
+++ b/rimg.js
@@ -510,7 +510,7 @@
         function getExtension(value){
             //find the extension of the value (URL)
             if(value){
-                return value.substr(value.lastIndexOf('.') + 1).toLowerCase();
+                return value.substr(value.lastIndexOf('.') + 1);
             }
             return null;
         }


### PR DESCRIPTION
.toLowerCase() breaks support for images with uppercase extension and is not necessary as far as I understand. Many devices store images as example.JPG.