### PR TITLE
Fix Chrome error with new getStyle() function

### DIFF
--- a/rimg.js
+++ b/rimg.js
@@ -13,7 +13,7 @@ function getStyle(oElm, css3Prop) {
   var strValue = "";
 
   if (window.getComputedStyle) {
-    strValue = getComputedStyle(oElm).getPropertyValue(css3Prop);
+    strValue = getComputedStyle(oElm)[css3Prop];
   }
   // IE
   else if (oElm.currentStyle) {


### PR DESCRIPTION
Reverted to the original notation to return "empty" instead of null. Otherwise Chrome complains for .resize() in line 373
